### PR TITLE
管理ポリシーattach/detach制限（administartor/administartor-group）

### DIFF
--- a/user-admin-policy.json
+++ b/user-admin-policy.json
@@ -52,6 +52,24 @@
         "arn:aws:iam::123456789123:user/[serverworks-user]",
         "arn:aws:iam::123456789123:user/[ops-user]"
       ]
+    },
+    {
+      "Effect": "Deny",
+      "Action": [
+        "iam:*"
+    ],
+      "Resource": [
+        "arn:aws:iam::123456789123:user/*",
+        "arn:aws:iam::123456789123:group/*"
+      ],
+      "Condition": {
+        "ArnLike": {
+          "iam:PolicyArn": [
+            "arn:aws:iam::aws:policy/*",
+            "arn:aws:iam::123456789123:policy/*"
+          ]
+       }
+      }
     }
   ]
 }


### PR DESCRIPTION
@akuira @y-baba @sakamoto-t @qryuu 
administratorユーザー、administrator-groupグループのインラインポリシーによって
管理ポリシーdetach/attachを制限するように改修

#4
参考：https://confluence.serverworks.co.jp/pages/viewpage.action?pageId=12750476